### PR TITLE
Entity attribute value stuff

### DIFF
--- a/src/swark/core.cljc
+++ b/src/swark/core.cljc
@@ -64,8 +64,12 @@
   "Returns `input` coerced to a trimmed string. Returns nil instead of a blank string."
   [input]
   (letfn [(non-blank [s] (when-not (str/blank? s) s))]
-    (when input
-      (some-> input name str/trim non-blank))))
+    (if (keyword? input) ; TODO: Add test for keyword case
+      (->> ((juxt (comp ->str namespace) (comp ->str name)) input)
+        (keep identity)
+        (str/join "/"))
+      (when input
+        (some-> input name str/trim non-blank)))))
 
 (defn unid
   "Returns a unique string that does is not yet contained in the existing set."

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -42,18 +42,19 @@
   [props]
   (filter (partial filter-eav props)))
 
-(defn mapify
+(defn- mapify
   [{ea :entity/attribute
     ev :entity/value
     a  :attribute
     v  :value}]
-  {[ea ev] {a v}})
+  {[ea ev] {ea ev a v}})
 
 (defn merge-rows
   [parse-props filter-props rows]
   (transduce
-    (comp (parser parse-props)
-          (filterer filter-props)
-          mapify)
-    (partial merge-with merge)
-    rows))
+   (comp
+    (parser parse-props)
+    (filterer filter-props)
+    (map mapify))
+   (partial merge-with merge)
+   rows))

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -50,7 +50,7 @@
   {[ea ev] {a v}})
 
 (defn merge-rows
-  [parse-props filter- rows]
+  [parse-props filter-props rows]
   (transduce
     (comp (parser parse-props)
           (filterer filter-props)

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -1,0 +1,23 @@
+(ns swark.eav)
+
+;; Storing data as Entity / Attribute / Value rows
+
+(defn ->rows
+  "Returns a sequence of vectors with [entity-attribute entity-value attribute value]
+  for each map-entry in map m."
+  [primary-key m]
+  (let [entry (find m primary-key)]
+    (assert entry "Mapentry can't be found!")
+    (map (partial into entry) (dissoc m primary-key))))
+
+(defn- parse [f input] (f input))
+
+(defn parse-row
+  "Returns row as a map with :entity/attribute, :entity/value, :attribute & :value. Applies supplied parsers on the fly."
+  ([row]
+   (parse-row nil row))
+  ([props row]
+   (let [keyseq [:entity/attribute :entity/value :attribute :value]]
+     (->> row
+          (zipmap keyseq)
+          (merge-with parse (select-keys props keyseq))))))

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -47,7 +47,7 @@
     ev :entity/value
     a  :attribute
     v  :value}]
-  {[ea ev] a v})
+  {[ea ev] {a v}})
 
 (defn merge-rows
   [parse-props filter- rows]

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -31,10 +31,12 @@
   (let [keyseq (keys props)
         props' (select-keys props (keys eav-map))
         filter-vals (apply juxt keyseq)]
-    (->> (select-keys eav-map keyseq)
-      (merge-with parse props')
-      filter-vals
-      (some identity))))
+    (if-not (seq props')
+      eav-map
+      (->> (select-keys eav-map keyseq)
+        (merge-with parse props')
+        filter-vals
+        (every? identity)))))
 
 (defn filterer
   [props]

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -12,7 +12,7 @@
 
 (defn- parse [f input] (f input))
 
-(defn parse-row
+(defn- parse-row
   "Returns row as a map with :entity/attribute, :entity/value, :attribute & :value. Applies supplied parsers on the fly."
   ([row]
    (parse-row nil row))
@@ -21,3 +21,21 @@
      (->> row
           (zipmap keyseq)
           (merge-with parse (select-keys props keyseq))))))
+
+(defn parser
+  [props]
+  (map (partial parse-row props)))
+
+(defn filter-eav
+  [props eav-map]
+  (let [keyseq (keys props)
+        props' (select-keys props (keys eav-map))
+        filter-vals (apply juxt keyseq)]
+    (->> (select-keys eav-map keyseq)
+      (merge-with parse props')
+      filter-vals
+      (some identity))))
+
+(defn filterer
+  [props]
+  (filter (partial filter-eav prpps)))

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -40,4 +40,4 @@
 
 (defn filterer
   [props]
-  (filter (partial filter-eav prpps)))
+  (filter (partial filter-eav props)))

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -26,7 +26,7 @@
   [props]
   (map (partial parse-row props)))
 
-(defn filter-eav
+(defn- filter-eav
   [props eav-map]
   (let [keyseq (keys props)
         props' (select-keys props (keys eav-map))

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -28,15 +28,15 @@
 
 (defn- filter-eav
   [props eav-map]
-  (let [keyseq (keys props)
-        props' (select-keys props (keys eav-map))
-        filter-vals (apply juxt keyseq)]
+  (let [props' (select-keys props (keys eav-map))
+        keyseq (keys props')
+        filter-vals (when (seq keyseq) (apply juxt keyseq))]
     (if-not (seq props')
-      eav-map
+      true ; Always match when there are no valid props to filter on.
       (->> (select-keys eav-map keyseq)
-        (merge-with parse props')
-        filter-vals
-        (every? identity)))))
+           (merge-with parse props')
+           filter-vals
+           (every? identity)))))
 
 (defn filterer
   [props]

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -41,3 +41,19 @@
 (defn filterer
   [props]
   (filter (partial filter-eav props)))
+
+(defn mapify
+  [{ea :entity/attribute
+    ev :entity/value
+    a  :attribute
+    v  :value}]
+  {[ea ev] a v})
+
+(defn merge-rows
+  [parse-props filter- rows]
+  (transduce
+    (comp (parser parse-props)
+          (filterer filter-props)
+          mapify)
+    (partial merge-with merge)
+    rows))

--- a/test/swark/eav_test.clj
+++ b/test/swark/eav_test.clj
@@ -37,5 +37,5 @@
               :value "Arnold"}]
     (t/is (true? (#'sut/filter-eav {:attribute #{:username} :value #{"Arnold"}} eav1)))
     (t/is (false? (#'sut/filter-eav {:attribute #{:username} :value #{"Zorro"}} eav1)))
-    (t/is (true? (#'sut/filter-eav {:entity/attribute #{:id} :entity/value #{1}})))
-    (t/is (false? (#'sut/filter-eav {:entity/attribute #{:id} :entity/value #{2}})))))
+    (t/is (true? (#'sut/filter-eav {:entity/attribute #{:id} :entity/value #{1}} eav1)))
+    (t/is (false? (#'sut/filter-eav {:entity/attribute #{:id} :entity/value #{2}} eav1)))))

--- a/test/swark/eav_test.clj
+++ b/test/swark/eav_test.clj
@@ -1,0 +1,31 @@
+(ns swark.eav-test
+  (:require [clojure.test :as t]
+            [swark.eav :as sut]))
+
+(def USER {:id 1 :username "Arnold"})
+(def USER2 #:user{:id 2 :name "Arnold" :city "Birmingham"})
+
+(t/deftest ->rows
+  (t/is (= [[:id 1 :username "Arnold"]]
+           (sut/->rows :id USER)))
+  (t/is (= [[:user/id 2 :user/name "Arnold"]
+            [:user/id 2 :user/city "Birmingham"]]
+           (sut/->rows :user/id USER2)))
+  (t/is (= [[:city/id 3 :city/name "Birmingham"]
+            [:city/id 4 :city/name "Cork"]]
+           (mapcat
+             (partial sut/->rows :city/id)
+             [#:city{:id 3 :name "Birmingham"}
+              #:city{:id 4 :name "Cork"}]))))
+
+(t/deftest parse-row
+  (t/is (= [{:entity/attribute :id :entity/value 1 :attribute :username :value "Arnold"}]
+           (map sut/parse-row (sut/->rows :id USER))))
+  (t/is (= [{:entity/attribute :user/id :entity/value 2 :attribute :user/name :value "Arnold"}
+            {:entity/attribute :user/id :entity/value 2 :attribute :user/city :value "Birmingham"}]
+           (map sut/parse-row (sut/->rows :user/id USER2))))
+  (t/is (= [{:entity/attribute :id :entity/value 1 :attribute "username" :value "Arnold"}]
+           (map (partial sut/parse-row {:attribute name}) (sut/->rows :id USER))))
+  (t/is (= [{:entity/attribute :user/id :entity/value :two :attribute "name" :value "Arnold"}
+            {:entity/attribute :user/id :entity/value :two :attribute "city" :value "Birmingham"}]
+           (map (partial sut/parse-row {:entity/value {2 :two} :attribute name}) (sut/->rows :user/id USER2)))))

--- a/test/swark/eav_test.clj
+++ b/test/swark/eav_test.clj
@@ -20,22 +20,22 @@
 
 (t/deftest parse-row
   (t/is (= [{:entity/attribute :id :entity/value 1 :attribute :username :value "Arnold"}]
-           (map sut/parse-row (sut/->rows :id USER))))
+           (map #'sut/parse-row (sut/->rows :id USER))))
   (t/is (= [{:entity/attribute :user/id :entity/value 2 :attribute :user/name :value "Arnold"}
             {:entity/attribute :user/id :entity/value 2 :attribute :user/city :value "Birmingham"}]
-           (map sut/parse-row (sut/->rows :user/id USER2))))
+           (map #'sut/parse-row (sut/->rows :user/id USER2))))
   (t/is (= [{:entity/attribute :id :entity/value 1 :attribute "username" :value "Arnold"}]
-           (map (partial sut/parse-row {:attribute name}) (sut/->rows :id USER))))
+           (map (partial #'sut/parse-row {:attribute name}) (sut/->rows :id USER))))
   (t/is (= [{:entity/attribute :user/id :entity/value :two :attribute "name" :value "Arnold"}
             {:entity/attribute :user/id :entity/value :two :attribute "city" :value "Birmingham"}]
-           (map (partial sut/parse-row {:entity/value {2 :two} :attribute name}) (sut/->rows :user/id USER2)))))
+           (map (partial #'sut/parse-row {:entity/value {2 :two} :attribute name}) (sut/->rows :user/id USER2)))))
 
 (t/deftest filter-eav
   (let [eav1 {:entity/attribute :id
               :entity/value 1
               :attribute :username
               :value "Arnold"}]
-    (t/is (true? (sut/filter-eav {:attribute #{:username} :value #{"Arnold"}} eav1)))
-    (t/is (false? (sut/filter-eav {:attribute #{:username} :value #{"Zorro"}} eav1)))
-    (t/is (true? (sut/filter-eav {:entity/attribute #{:id} :entity/value #{1}})))
-    (t/is (false? (sut/filter-eav {:entity/attribute #{:id} :entity/value #{2}})))))
+    (t/is (true? (#'sut/filter-eav {:attribute #{:username} :value #{"Arnold"}} eav1)))
+    (t/is (false? (#'sut/filter-eav {:attribute #{:username} :value #{"Zorro"}} eav1)))
+    (t/is (true? (#'sut/filter-eav {:entity/attribute #{:id} :entity/value #{1}})))
+    (t/is (false? (#'sut/filter-eav {:entity/attribute #{:id} :entity/value #{2}})))))

--- a/test/swark/eav_test.clj
+++ b/test/swark/eav_test.clj
@@ -29,3 +29,13 @@
   (t/is (= [{:entity/attribute :user/id :entity/value :two :attribute "name" :value "Arnold"}
             {:entity/attribute :user/id :entity/value :two :attribute "city" :value "Birmingham"}]
            (map (partial sut/parse-row {:entity/value {2 :two} :attribute name}) (sut/->rows :user/id USER2)))))
+
+(t/deftest filter-eav
+  (let [eav1 {:entity/attribute :id
+              :entity/value 1
+              :attribute :username
+              :value "Arnold"}]
+    (t/is (true? (sut/filter-eav {:attribute #{:username} :value #{"Arnold"}} eav1)))
+    (t/is (false? (sut/filter-eav {:attribute #{:username} :value #{"Zorro"}} eav1)))
+    (t/is (true? (sut/filter-eav {:entity/attribute #{:id} :entity/value #{1}})))
+    (t/is (false? (sut/filter-eav {:entity/attribute #{:id} :entity/value #{2}})))))


### PR DESCRIPTION
Implement functionality in order to parse, filter and merge (csv) rows in terms of its entity, attribute and value.

- `eav/->rows` returns a sequence of vectors in the form of [ev ea e v] for every map-entry in map m.
- `eav/parse-row` returns the row as a map with :entity/attribute, :entity/value, :attribute & :value keys. Applying supplied parsers on the fly.
- `eav/filter-eav` returns true if every predicate in props (:entity/attribute, :entity/value, :attribute & value) returns a logical true value for the eav-map.
- `eav/merge-rows` combines the parser and filterer into a transducer that returns the row data, parsed, filtered and merged in to a single map.