### PR TITLE
Implement parser lookup in parse-row

### DIFF
--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -2,7 +2,7 @@
 
 ;; Storing data as Entity / Attribute / Value rows
 
-(defn- parse [f input] (f input))
+(defn- parse [f input] (cond-> input (ifn? f) f))
 
 (defn ->rows
   "Returns a sequence of vectors with [entity-attribute entity-value attribute value]

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -39,7 +39,15 @@
      (assert-ifn-vals props)
      (->> row
           (zipmap keyseq)
-          (merge-with parse props)))))
+          (merge-with parse props))))
+  ([props lookup row] ;TODO: Merge lookop into props?
+    (let [m (parse-row props row)
+          ea-parser (get lookup :entity/attribute identity)
+          eaa (juxt (comp ea-parser :entity/attribute) :attribute)
+          value-parser (get lookup (eaa m))]
+      (cond-> m
+        ea-parser (update:entity/attribute ea-parser)
+        value-parser (update :value value-parser)))))
 
 (defn parser
   [props]

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -33,7 +33,7 @@
   "Returns row as a map with :entity/attribute, :entity/value, :attribute & :value. Applies supplied parsers on the fly for thise mapentries. You can supply a value parser lookup via :value/parsers, if a parser can be found by [:entity/attribute :attribute], this is used to parse the :value of the row's eav-map."
   ([row]
    (parse-row nil row))
-  ([{:value/keys [parsers] props} row]
+  ([{:value/keys [parsers] :as props} row]
    (let [keyseq [:entity/attribute :entity/value :attribute :value]
          props  (select-keys props keyseq)
          _      (assert-ifn-vals props)

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -42,11 +42,9 @@
           (merge-with parse props))))
   ([props lookup row] ;TODO: Merge lookop into props?
     (let [m (parse-row props row)
-          ea-parser (get lookup :entity/attribute identity)
-          eaa (juxt (comp ea-parser :entity/attribute) :attribute)
+          eaa (juxt :entity/attribute :attribute)
           value-parser (get lookup (eaa m))]
       (cond-> m
-        ea-parser (update:entity/attribute ea-parser)
         value-parser (update :value value-parser)))))
 
 (defn parser

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -41,7 +41,7 @@
                      (zipmap keyseq)
                      (merge-with parse props))
          ea-vector (juxt :entity/attribute :attribute)
-         v-parser  (get parsers (ea-vector m))]
+         v-parser  (get parsers (ea-vector item))]
      (cond-> item v-parser (update :value v-parser)))))
 
 (defn parser

--- a/src/swark/eav.cljc
+++ b/src/swark/eav.cljc
@@ -35,14 +35,14 @@
    (parse-row nil row))
   ([{:value/keys [parsers] :as props} row]
    (let [keyseq [:entity/attribute :entity/value :attribute :value]
-         props  (select-keys props keyseq)
-         _      (assert-ifn-vals props)
-         item   (->> row
-                  (zipmap keyseq)
-                  (merge-with parse props))
-         ea-vec (juxt :entity/attribute :attribute)
-         vparse (get lookup (ea-vec m))]
-     (cond-> item vparse (update :value vparse)))))
+         props     (select-keys props keyseq)
+         _         (assert-ifn-vals props)
+         item      (->> row
+                     (zipmap keyseq)
+                     (merge-with parse props))
+         ea-vector (juxt :entity/attribute :attribute)
+         v-parser  (get parsers (ea-vector m))]
+     (cond-> item v-parser (update :value v-parser)))))
 
 (defn parser
   [props]

--- a/test/swark/eav_test.clj
+++ b/test/swark/eav_test.clj
@@ -38,7 +38,17 @@
            (map (partial #'sut/parse-row {:attribute name}) (sut/->rows USER))))
   (t/is (= [{:entity/attribute :user/id :entity/value :two :attribute "name" :value "Arnold"}
             {:entity/attribute :user/id :entity/value :two :attribute "city" :value "Birmingham"}]
-           (map (partial #'sut/parse-row {:entity/value {2 :two} :attribute name}) (sut/->rows USER2 {:primary/key :user/id})))))
+           (map (partial #'sut/parse-row {:entity/value {2 :two} :attribute name}) (sut/->rows USER2 {:primary/key :user/id}))))
+  (t/is (= {:entity/attribute :user/id
+            :entity/value     2
+            :attribute        :user/type
+            :value            :member}
+           (sut/parse-row
+             {:entity/attribute swark/->keyword
+              :entity/value     edn/read-string
+              :attribute        swark/->keyword}
+             {[:user/id :user/type] swark/->keyword}
+             ["user/id" "2" "user/type" "member"]))))
 
 (t/deftest filter-eav
   (let [eav1 {:entity/attribute :id

--- a/test/swark/eav_test.clj
+++ b/test/swark/eav_test.clj
@@ -46,8 +46,8 @@
            (#'sut/parse-row
              {:entity/attribute swark/->keyword
               :entity/value     edn/read-string
-              :attribute        swark/->keyword}
-             {[:user/id :user/type] swark/->keyword}
+              :attribute        swark/->keyword
+              :value/parsers    {[:user/id :user/type] swark/->keyword}}
              ["user/id" "2" "user/type" "member"]))))
 
 (t/deftest filter-eav

--- a/test/swark/eav_test.clj
+++ b/test/swark/eav_test.clj
@@ -43,7 +43,7 @@
             :entity/value     2
             :attribute        :user/type
             :value            :member}
-           (sut/parse-row
+           (#'sut/parse-row
              {:entity/attribute swark/->keyword
               :entity/value     edn/read-string
               :attribute        swark/->keyword}


### PR DESCRIPTION
Make sure you can actually parse the entity-attribute and value parts of a row. Supply a parser lookup map to parse-row:

So you can parse a users age or product category like this
```
{[:user/id :user/age] edn/read-string
 [:product/id :product/category] keyword}
```