### PR TITLE
Fix memoir caching bug for nil and false return values

### DIFF
--- a/src/swark/core.cljc
+++ b/src/swark/core.cljc
@@ -210,7 +210,8 @@
           (reset! state nil)
 
           :else
-          (or (get @state args)
-              (-> state
-                  (swap! assoc args (apply f args))
-                  (get args))))))))
+          (if (contains? @state args)
+            (get @state args)
+            (-> state
+                (swap! assoc args (apply f args))
+                (get args))))))))

--- a/test/swark/core_test.clj
+++ b/test/swark/core_test.clj
@@ -156,6 +156,12 @@
       (t/is (not= x (random 999))) ; Caches a new result
       (t/is (= (random 999) (random 999))) ; Returns the new cached input
       (t/is (nil? (random :flush 99)))) ; Returns nil if the cache to flush subset is nonexistent
+    (t/testing "Caches nil return values"
+      (let [call-count (atom 0)
+            nil-fn     (sut/memoir (fn [x] (swap! call-count inc) nil))]
+        (nil-fn :a)
+        (nil-fn :a)
+        (t/is (= 1 @call-count))))
     (t/testing "Flush the complete cache"
       (t/is (nil? (random :flush)))
       (t/is (not= y (random 9999))))))


### PR DESCRIPTION
## Summary

- `memoir` used `or` to check the cache, which caused functions returning `nil` or `false` to bypass the cache on every call — the underlying function was invoked repeatedly instead of once
- Replaced `(or (get @state args) ...)` with `(if (contains? @state args) ...)`, matching the approach used by Clojure's built-in `memoize`

## Test plan

- [x] A `memoir`-wrapped function returning `nil` is called only once for repeated calls with the same args (verified with an atom counter)
- [x] All existing `memoir` tests still pass
- [x] Full test suite passes: `clojure -X:test/run`