### PR TITLE
Add flush-signal sentinel and memoir integration for defmemo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,17 @@
 
 - `swark.core/defmemo` - Macro that defines a memoized function and returns it.
   Supports `^:dynamic` on the name, making the var rebindable via `binding`.
-  `(defmemo my-fn [x] (* x x))` expands to `(def my-fn (memoize (fn [x] (* x x))))`.
+  Accepts an optional memoizer as the second argument, defaulting to `memoize`.
+  `(defmemo my-fn [x] (* x x))` uses `memoize`.
+  `(defmemo my-fn memoir [x] (* x x))` uses `memoir`, gaining flush capability.
+
+- `swark.core/flush-signal` - Sentinel value for triggering cache eviction in `memoir` fns.
+  Replaces the previous `:flush` keyword convention, which prevented `:flush` from being
+  used as a legitimate cached argument.
+  `(f flush-signal)` evicts the entire cache. `(f flush-signal arg)` evicts a single entry.
 
 ### Fixed
 
 - `swark.core/memoir` - Functions returning `nil` or `false` were not cached; the underlying function was called on every invocation. Fixed by replacing the `or`-based cache check with `contains?`.
+
+- `swark.core/memoir` - The `:flush` keyword could never be used as a legitimate cached argument. Replaced the keyword sentinel with a private `Object.` instance (`flush-signal`) checked via `identical?`.

--- a/src/swark/core.cljc
+++ b/src/swark/core.cljc
@@ -198,12 +198,16 @@
        (def ~name memoized-fn#)
        memoized-fn#)))
 
+(def flush-signal
+  "Sentinel value. Pass as the first argument to a memoir fn to trigger cache eviction."
+  (Object.))
+
 (defn memoir
   "Like memoize but with flush functionality."
   [f]
   (let [state (atom nil)]
     (fn memoir* [& args]
-      (let [flush?     (-> args first #{:flush})
+      (let [flush?     (identical? (first args) flush-signal)
             flush-args (-> args rest seq)]
         (cond
           (and flush? flush-args)

--- a/src/swark/core.cljc
+++ b/src/swark/core.cljc
@@ -185,13 +185,18 @@
 
 (defmacro defmemo
   {:added "0.1.52"
-   :arglists '([name & fndef])
-   :doc "Defines a memoized function and returns it.
-   `(defmemo my-fn [x] (* x x)) => (def my-fn (memoize (fn [x] (* x x))))`"}
-  [name & fndef]
-  `(let [memoized-fn# (memoize (fn ~@fndef))]
-     (def ~name memoized-fn#)
-     memoized-fn#))
+   :arglists '([name & fndef] [name memo & fndef])
+   :doc "Defines a memoized function and returns it. Accepts an optional memoizer
+   as the second argument, defaulting to memoize.
+   `(defmemo my-fn [x] (* x x))` uses memoize.
+   `(defmemo my-fn memoir [x] (* x x))` uses memoir, gaining :flush capability."}
+  [name & args]
+  (let [[memo fndef] (if (symbol? (first args))
+                       [(first args) (rest args)]
+                       [`memoize args])]
+    `(let [memoized-fn# (~memo (fn ~@fndef))]
+       (def ~name memoized-fn#)
+       memoized-fn#)))
 
 (defn memoir
   "Like memoize but with flush functionality."

--- a/test/swark/core_test.clj
+++ b/test/swark/core_test.clj
@@ -142,6 +142,19 @@
           (*square* 5)
           (t/are [result expr] (= result expr)
             1  @call-count
+            25 (*square* 5))))))
+  (t/testing "accepts memoir as memoizer, gaining :flush capability"
+    (binding [*square* (sut/defmemo square sut/memoir [x] (* x x))]
+      (t/is (= 25 (*square* 5)))
+      (*square* :flush)
+      (let [call-count (atom 0)]
+        (binding [*square* (sut/memoir (fn [x] (swap! call-count inc) (* x x)))]
+          (*square* 5)
+          (*square* 5)
+          (*square* :flush 5)
+          (*square* 5)
+          (t/are [result expr] (= result expr)
+            2  @call-count
             25 (*square* 5)))))))
 
 (t/deftest memoir

--- a/test/swark/core_test.clj
+++ b/test/swark/core_test.clj
@@ -146,12 +146,12 @@
   (t/testing "accepts memoir as memoizer, gaining :flush capability"
     (binding [*square* (sut/defmemo square sut/memoir [x] (* x x))]
       (t/is (= 25 (*square* 5)))
-      (*square* :flush)
+      (*square* sut/flush-signal)
       (let [call-count (atom 0)]
         (binding [*square* (sut/memoir (fn [x] (swap! call-count inc) (* x x)))]
           (*square* 5)
           (*square* 5)
-          (*square* :flush 5)
+          (*square* sut/flush-signal 5)
           (*square* 5)
           (t/are [result expr] (= result expr)
             2  @call-count
@@ -165,16 +165,22 @@
       (t/is (= x (random 999)))
       (t/is (= y (random 9999))))
     (t/testing "Flush a specific subset of the cache"
-      (t/is (= x (random :flush 999))) ; Returns the flushed subset of the cache
-      (t/is (not= x (random 999))) ; Caches a new result
-      (t/is (= (random 999) (random 999))) ; Returns the new cached input
-      (t/is (nil? (random :flush 99)))) ; Returns nil if the cache to flush subset is nonexistent
+      (t/is (= x (random sut/flush-signal 999)))
+      (t/is (not= x (random 999)))
+      (t/is (= (random 999) (random 999)))
+      (t/is (nil? (random sut/flush-signal 99))))
     (t/testing "Caches nil return values"
       (let [call-count (atom 0)
             nil-fn     (sut/memoir (fn [x] (swap! call-count inc) nil))]
         (nil-fn :a)
         (nil-fn :a)
         (t/is (= 1 @call-count))))
+    (t/testing ":flush keyword can now be cached as a legitimate argument"
+      (let [call-count (atom 0)
+            f          (sut/memoir (fn [x] (swap! call-count inc) x))]
+        (f :flush)
+        (f :flush)
+        (t/is (= 1 @call-count))))
     (t/testing "Flush the complete cache"
-      (t/is (nil? (random :flush)))
+      (t/is (nil? (random sut/flush-signal)))
       (t/is (not= y (random 9999))))))


### PR DESCRIPTION
## Summary

- Replaces `memoir`'s `:flush` keyword sentinel with `flush-signal`, a unique `Object.` instance checked via `identical?`. This means `:flush` can now be a legitimate cached argument to any `memoir`-wrapped function
- `defmemo` now accepts an optional memoizer as the second argument (defaults to `memoize`). Pass `memoir` to gain flush capability: `(defmemo my-fn memoir [x] (* x x))`
- Adds `swark.core/flush-signal` as a public var callers use to trigger eviction: `(f flush-signal)` or `(f flush-signal arg)`

## Test plan

- [x] `:flush` keyword is now cached correctly as a regular argument
- [x] `flush-signal` triggers full and partial cache eviction
- [x] `defmemo` with `memoir` as memoizer gains flush behaviour
- [x] `defmemo` without explicit memoizer still defaults to `memoize`
- [x] Full test suite passes: `clojure -X:test/run`