### PR TITLE
Refactor filter-keys to use reduce-kv with cond->

### DIFF
--- a/src/swark/core.cljc
+++ b/src/swark/core.cljc
@@ -45,10 +45,11 @@
    logical true on evaluation of (pred key).
    `(filter-keys {:a 1 \"b\" 2} keyword?) => {:a 1}`"}
   [map pred]
-  (cond->> map
-    pred    (filter (comp pred key))
-    map     seq
-    :always (into {})))
+  (reduce-kv
+    (fn filter-key* [acc k v]
+      (cond-> acc (or (not pred) (pred k)) (assoc k v)))
+    {}
+    map))
 
 (declare jab)
 

--- a/test/swark/core_test.clj
+++ b/test/swark/core_test.clj
@@ -45,7 +45,8 @@
       {:user-id 1}            (complement namespace)
       {:user/name "Username"} (comp #{"user"} namespace)
       {::test "Testdata"}     (comp #{ns-str} namespace)
-      {}                     (comp #{"unknown"} namespace))))
+      {}                     (comp #{"unknown"} namespace)
+      map                    nil)))
 
 (t/deftest select-namespaced
   (let [map {:user-id 1 :user/name "Username" ::test "Testdata"}]


### PR DESCRIPTION
Closes #30

## Summary

Replaces the `cond->>` + `filter` + `into {}` chain in `filter-keys` with a single `reduce-kv` + `cond->` traversal, eliminating intermediate sequence allocation.

## Acceptance criteria

- [x] `filter-keys` is rewritten using `reduce-kv` and `cond->`
- [x] All existing tests pass unchanged
- [x] `select-namespaced` (downstream caller) continues to work correctly
- [x] `:added` metadata and docstring are preserved
- [x] Nil pred behaviour (return full map) is covered by a new test case